### PR TITLE
Add support for rowing activities

### DIFF
--- a/Activities.Core/Extensions/MathExtensions.cs
+++ b/Activities.Core/Extensions/MathExtensions.cs
@@ -8,25 +8,23 @@ namespace Activities.Core.Extensions
 {
     public static class MathExtensions
     {
-        public static string ToPaceString(this double metersPerSecond, bool showSuffix = false)
+        public static string ToPaceString(this double metersPerSecond, String activityType, bool showSuffix = false)
         {
             if (double.IsNaN(metersPerSecond) || metersPerSecond == 0.0)
             {
                 return string.Empty;
             }
 
-            var averageSpeed = 1000 / metersPerSecond / 60;
-            var averageSpeedMin = Math.Floor(averageSpeed);
-            var averageSpeedSeconds = Math.Round(averageSpeed % 1 * 60);
+            var isRowing = activityType == "Rowing";
+            var lapDistance = isRowing ? 500 : 1000;
+            var suffix = isRowing ? " /500m" : " /km";
 
-            if (averageSpeedSeconds == 60)
-            {
-                averageSpeedMin += 1;
-                averageSpeedSeconds = 0;
-            }
+            var averageSpeed = Math.Round(lapDistance / metersPerSecond);
+            var averageSpeedMin = Math.Floor(averageSpeed / 60);
+            var averageSpeedSeconds = averageSpeed % 60;
 
             var paceString = $"{averageSpeedMin}:{(averageSpeedSeconds < 10 ? "0" : "")}{averageSpeedSeconds}";
-            return showSuffix ? $"{paceString} /km" : paceString;
+            return showSuffix ? $"{paceString}{suffix}" : paceString;
         }
 
         public static double? AverageBy<T>(this IEnumerable<T> items, Func<T, double?> durationFunc, Func<T, double?> paceFunc)

--- a/Activities.Strava/Endpoints/ActivitiesClient.cs
+++ b/Activities.Strava/Endpoints/ActivitiesClient.cs
@@ -131,6 +131,7 @@ namespace Activities.Strava.Endpoints
                 case "VirtualRide":
                 case "Swim":
                 case "NordicSki":
+                case "Rowing":
                     return true;
                 default:
                     return false;

--- a/Activities.Tests/IntervalsServiceTests.cs
+++ b/Activities.Tests/IntervalsServiceTests.cs
@@ -74,7 +74,7 @@ namespace Activities.Tests
                         Assert.AreEqual(
                             expectedResult,
                             lap.IsInterval,
-                            $"{(expectedResult ? "Lap not found" : "Didn't expect lap")}: {lapIndex + 1} ({lap.AverageSpeed.ToPaceString()}, {lap.Distance.ToKmString()}, {lap.ElapsedTime.ToTimeString()}) - https://www.strava.com/activities/{stravaId}");
+                            $"{(expectedResult ? "Lap not found" : "Didn't expect lap")}: {lapIndex + 1} ({lap.AverageSpeed.ToPaceString("Run")}, {lap.Distance.ToKmString()}, {lap.ElapsedTime.ToTimeString()}) - https://www.strava.com/activities/{stravaId}");
                     }
                 });
         }

--- a/Activities.Tests/MathExtensionsTests.cs
+++ b/Activities.Tests/MathExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Activities.Tests
         public void Speed(double pace)
         {
             var metersPerSecond = pace.ToMetersPerSecond();
-            var paceString = metersPerSecond.ToPaceString().Replace(":", ".");
+            var paceString = metersPerSecond.ToPaceString("Run").Replace(":", ".");
             Assert.AreEqual(pace.ToString("0.00", CultureInfo.InvariantCulture), paceString);
         }
 

--- a/Activities.Web/ClientApp/src/components/activities/ActivitiesPage.tsx
+++ b/Activities.Web/ClientApp/src/components/activities/ActivitiesPage.tsx
@@ -41,6 +41,11 @@ const ActivitiesPage: React.FC = () => {
       });
   }, [filters]);
 
+  // Average pace will show min/500m if showing only rowing activities, and min/km
+  // otherwise (including if filter is set to “all”, no matter what kinds of
+  // activities are actually visible).
+  const activityType = (filters === undefined) ? '' : ((filters.get('type') ?? 'All') as string);
+
   const showLactate = (activities
     && activities.filter((group) => group.items?.filter((activity) => activity.lactate).length > 0 || false).length > 0) === true;
 
@@ -65,7 +70,7 @@ const ActivitiesPage: React.FC = () => {
                         <th colSpan={2} id={group.name}>{group.name}</th>
                         <ValueTh items={group.items} valueFunc={(item) => item.distance} title="Distance" />
                         <ValueTh items={group.items} valueFunc={(item) => item.elapsedTime} title="Time" />
-                        <ValueTh items={group.items} valueFunc={(item) => item.pace} title="Pace" />
+                        <ValueTh items={group.items} valueFunc={(item) => item.pace} activityType={activityType} title="Pace" />
                         <ValueTh items={group.items} valueFunc={(item) => item.heartrate} title="Heartrate" />
                         {showLactate && <ValueTh items={group.items} valueFunc={(item) => item.lactate} title="Lactate" />}
                         {showFeeling && <th title="Feeling">&nbsp;&nbsp;&nbsp;</th>}

--- a/Activities.Web/ClientApp/src/components/activityDetails/ActivityDetailsPage.tsx
+++ b/Activities.Web/ClientApp/src/components/activityDetails/ActivityDetailsPage.tsx
@@ -221,7 +221,8 @@ const ActivityDetailsPage: React.FC = () => {
             </li>
             {activity.averageSpeed > 0 && (
               <li>
-                <strong>Pace:</strong> {getPaceString(activity.averageSpeed)} (avg), {getPaceString(activity.maxSpeed)}{' '}
+                <strong>Pace:</strong> {getPaceString(activity.averageSpeed, activity.type)} (avg),
+                  {getPaceString(activity.maxSpeed, activity.type)}{' '}
                 (max)
               </li>
             )}
@@ -239,7 +240,12 @@ const ActivityDetailsPage: React.FC = () => {
 
           {activity.laps && activity.laps.length > 1 && (
           <ScrollableBox>
-            <LapsChart laps={activity.laps} averageIntervalPace={averageIntervalPace} last60DaysIntervalPace={last60DaysIntervalPace} />
+            <LapsChart
+              laps={activity.laps}
+              activityType={activity.type}
+              averageIntervalPace={averageIntervalPace}
+              last60DaysIntervalPace={last60DaysIntervalPace}
+            />
           </ScrollableBox>
           )}
 

--- a/Activities.Web/ClientApp/src/components/activityDetails/LapsChart.tsx
+++ b/Activities.Web/ClientApp/src/components/activityDetails/LapsChart.tsx
@@ -72,9 +72,15 @@ const NormalizeChartData = (
 
 const LapsChart: React.FC<{
   laps: Lap[],
+  activityType: String,
   averageIntervalPace: number | undefined,
   last60DaysIntervalPace: number | undefined
-}> = ({ laps, averageIntervalPace, last60DaysIntervalPace }) => {
+}> = ({
+  laps,
+  activityType,
+  averageIntervalPace,
+  last60DaysIntervalPace,
+}) => {
   const [hint, setHint] = useState<{ value: any; owner: string } | null>();
   const speedPadding = 0.1;
 
@@ -107,8 +113,8 @@ const LapsChart: React.FC<{
         x,
         y: averageLapSpeed,
         yHeartrate: lap.averageHeartrate,
-        label: isPauseLap(lapIndex, laps) ? '' : getPaceString(averageLapSpeed),
-        hint: `Pace: ${getPaceString(lap.averageSpeed, true)}
+        label: isPauseLap(lapIndex, laps) ? '' : getPaceString(averageLapSpeed, activityType),
+        hint: `Pace: ${getPaceString(lap.averageSpeed, activityType, true)}
         Heartrate: ${lap.averageHeartrate}
         Distance: ${getKmString(lap.distance)}
       Duration: ${getTimeString(lap.elapsedTime)} (Moving time: ${getTimeString(lap.movingTime)})
@@ -174,7 +180,7 @@ const LapsChart: React.FC<{
           xDomain={[0, chart.totalMovingTime]}
           xAxisType={AxisTypes.None}
           yDomain={[-0.05, 1.05]}
-          yTickFormat={(distancePerSecond) => getPaceString(distancePerSecond)}
+          yTickFormat={(distancePerSecond) => getPaceString(distancePerSecond, activityType)}
           margin={{ bottom: 15 }}
           hideYAxis
         >
@@ -234,8 +240,8 @@ const LapsChart: React.FC<{
       )}
       {averageIntervalPace && (
         <IntervalPaceContainer>
-          <span>Average interval pace: <strong>{getPaceString(averageIntervalPace || 0)}</strong></span>
-          <span> - Last 60 days: <strong>{getPaceString(last60DaysIntervalPace || 0)}</strong></span>
+          <span>Average interval pace: <strong>{getPaceString(averageIntervalPace || 0, activityType)}</strong></span>
+          <span> - Last 60 days: <strong>{getPaceString(last60DaysIntervalPace || 0, activityType)}</strong></span>
         </IntervalPaceContainer>
       )}
     </div>

--- a/Activities.Web/ClientApp/src/components/intervals/IntervalsPage.tsx
+++ b/Activities.Web/ClientApp/src/components/intervals/IntervalsPage.tsx
@@ -34,6 +34,7 @@ interface Activity {
   id: number;
   date: string;
   name: string;
+  type: string;
   description: string;
   interval_AveragePace: string;
   interval_AverageHeartrate: number;
@@ -192,10 +193,13 @@ const IntervalsPage: React.FC = () => {
             <Box>
               <SubHeader>Pace</SubHeader>
               {shortPaces && shortPaces.length > 0 && (
+                // y-axis will show min/500m if showing only rowing activities, and min/km
+                // otherwise (including if filter is set to “all”, no matter what kinds of
+                // activities are actually visible).
                 <Chart
                   xType="ordinal"
                   yDomain={[3, 6]}
-                  yTickFormat={(distancePerSecond) => getPaceString(distancePerSecond)}
+                  yTickFormat={(distancePerSecond) => getPaceString(distancePerSecond, (filters!.get('type') ?? 'All') as string)}
                 >
                   <VerticalBarSeries
                     getY={(d) => (d.y < 3 ? 3 : d.y)}
@@ -345,7 +349,7 @@ const IntervalsPage: React.FC = () => {
                                     activity.interval_Laps,
                                     (item) => item.elapsedTime,
                                     (item) => item.averageSpeed,
-                                  ) || 0)}
+                                  ) || 0, activity.type)}
                                 </th>
                                 <th title="Average heartrate">
                                   {Math.round(
@@ -377,7 +381,7 @@ const IntervalsPage: React.FC = () => {
                                     />
                                   </NoWrapTd>
                                   <NoWrapTd title="Pace">
-                                    <LapLabel>{getPaceString(lap.averageSpeed)}</LapLabel>
+                                    <LapLabel>{getPaceString(lap.averageSpeed, activity.type)}</LapLabel>
                                     <LapFactor
                                       style={{
                                         width: `${lap.averageSpeedFactor * 100}%`,

--- a/Activities.Web/ClientApp/src/components/races/races.tsx
+++ b/Activities.Web/ClientApp/src/components/races/races.tsx
@@ -9,6 +9,7 @@ import Loader, { LoadingStatus } from '../utils/Loader';
 interface Activity {
   id: number;
   name: string;
+  type: string;
   movingTime: number;
   startDate: string;
   distance: number;
@@ -62,7 +63,7 @@ const RacesPage: React.FC = () => {
                     </div>
                   </td>
                   <NoWrapTd>{getKmString(activity.distance)}</NoWrapTd>
-                  <NoWrapTd>{getPaceString(activity.averageSpeed)}</NoWrapTd>
+                  <NoWrapTd>{getPaceString(activity.averageSpeed, activity.type)}</NoWrapTd>
                   <NoWrapTd>{getTimeString(activity.movingTime)}</NoWrapTd>
                   <NoWrapTd>{getDateString(activity.startDate)}</NoWrapTd>
                 </tr>

--- a/Activities.Web/ClientApp/src/components/scatter/ScatterPage.tsx
+++ b/Activities.Web/ClientApp/src/components/scatter/ScatterPage.tsx
@@ -27,8 +27,10 @@ interface Axis {
 
 const getAxisSettings = (key: string, lockAxisFilter: boolean): Axis => {
   if (key === 'pace') {
+    // TODO: If this page is ever made public, apply the same logic with
+    // propagating the activity type from the filter as in the other pages.
     return {
-      format: (value: number) => getPaceString(value),
+      format: (value: number) => getPaceString(value, ''),
       min: lockAxisFilter ? 3.7 : undefined,
       max: lockAxisFilter ? 5.5 : undefined,
     };

--- a/Activities.Web/ClientApp/src/components/utils/ActivityFilter.tsx
+++ b/Activities.Web/ClientApp/src/components/utils/ActivityFilter.tsx
@@ -156,6 +156,7 @@ const ActivityFilter: React.FC<ActivityFilterProps> = (props) => {
         <option value="VirtualRide">VirtualRide</option>
         <option value="NordicSki">NordicSki</option>
         <option value="Swim">Swim</option>
+        <option value="Rowing">Rowing</option>
       </Dropdown>
       <Dropdown
         disabled={isLoading}

--- a/Activities.Web/ClientApp/src/components/utils/ActivityTr.tsx
+++ b/Activities.Web/ClientApp/src/components/utils/ActivityTr.tsx
@@ -96,7 +96,7 @@ const ActivityTr: React.FC<{ activity: Activity, showLactate: boolean, showFeeli
       {activity.laps && <ValueTd item={activity.laps} title="Laps" />}
       <ValueTd item={activity.distance} title="Distance" />
       <ValueTd item={activity.elapsedTime} title="Time" />
-      <ValueTd item={activity.pace} title="Pace" />
+      <ValueTd item={activity.pace} activityType={activity.type} title="Pace" />
       <ValueTd item={activity.heartrate} title="Heartrate" />
       {showLactate && <ValueTd item={activity.lactate} title="Lactate" />}
       {(showFeeling && activity.feeling)

--- a/Activities.Web/ClientApp/src/components/utils/Formatters.tsx
+++ b/Activities.Web/ClientApp/src/components/utils/Formatters.tsx
@@ -2,21 +2,20 @@
 
 export const round = (value: number, decimals: number) => value.toFixed(decimals);
 
-export const getPaceString = (metersPerSecond: number, showSuffix: boolean = false) => {
+export const getPaceString = (metersPerSecond: number, activityType: String, showSuffix: boolean = false) => {
   if (Number.isNaN(metersPerSecond) || metersPerSecond === 0) {
     return '';
   }
 
-  const averageSpeed = 1000 / metersPerSecond / 60;
-  let averageSpeedMin = Math.floor(averageSpeed);
-  let averageSpeedSeconds = Math.round((averageSpeed % 1) * 60);
+  const isRowing = (activityType === 'Rowing');
+  const lapDistance = isRowing ? 500 : 1000;
+  const suffix = isRowing ? ' /500m' : ' /km';
 
-  if (averageSpeedSeconds === 60) {
-    averageSpeedMin += 1;
-    averageSpeedSeconds = 0;
-  }
+  const averageSpeed = Math.round(lapDistance / metersPerSecond);
+  const averageSpeedMin = Math.floor(averageSpeed / 60);
+  const averageSpeedSeconds = averageSpeed % 60;
 
-  return `${averageSpeedMin}:${averageSpeedSeconds < 10 ? '0' : ''}${averageSpeedSeconds}${showSuffix ? ' /km' : ''}`;
+  return `${averageSpeedMin}:${averageSpeedSeconds < 10 ? '0' : ''}${averageSpeedSeconds}${showSuffix ? suffix : ''}`;
 };
 
 export const getMetersPerSecond = (minPerKm: number) => {

--- a/Activities.Web/ClientApp/src/components/utils/ValueTd.tsx
+++ b/Activities.Web/ClientApp/src/components/utils/ValueTd.tsx
@@ -38,8 +38,8 @@ const ValueContainer = styled.div`
   position: relative;
 `;
 
-const ValueTd: React.FC<{ item: ItemValue, title?: string | undefined }> = (props) => {
-  const { item, title } = props;
+const ValueTd: React.FC<{ item: ItemValue, activityType?: string | undefined, title?: string | undefined }> = (props) => {
+  const { item, activityType, title } = props;
 
   if (item == null) {
     return <td><ValueTdLabel>-</ValueTdLabel></td>;
@@ -54,7 +54,7 @@ const ValueTd: React.FC<{ item: ItemValue, title?: string | undefined }> = (prop
       color = '#005dff';
       break;
     case ItemValueType.MetersPerSecond:
-      value = getPaceString(item.value);
+      value = getPaceString(item.value, activityType ?? '');
       color = '#00a000';
       break;
     case ItemValueType.TimeInSeconds:

--- a/Activities.Web/ClientApp/src/components/utils/ValueTh.tsx
+++ b/Activities.Web/ClientApp/src/components/utils/ValueTh.tsx
@@ -13,8 +13,14 @@ const Th = styled.th`
 const ValueTh: React.FC<{
   items: ResultItem[],
   valueFunc: (item:ResultItem) => ItemValue,
+  activityType?: string | undefined,
   title?: string | undefined }> = (props) => {
-  const { items, valueFunc, title } = props;
+  const {
+    items,
+    valueFunc,
+    activityType,
+    title,
+  } = props;
 
   if (items == null || items.length === 0) {
     return <Th>&nbps;</Th>;
@@ -36,7 +42,8 @@ const ValueTh: React.FC<{
       value = getKmString(summedValue);
       break;
     case ItemValueType.MetersPerSecond:
-      value = getPaceString(AveragePace(items, (item) => item.elapsedTime?.value, (item) => item.pace?.value) || 0, true);
+      value = getPaceString(AveragePace(items, (item) => item.elapsedTime?.value, (item) => item.pace?.value) || 0,
+        activityType ?? '', true);
       break;
     case ItemValueType.TimeInSeconds:
       value = getTimeString(summedValue);

--- a/Activities.Web/ClientApp/src/styles/TypeEmoji.tsx
+++ b/Activities.Web/ClientApp/src/styles/TypeEmoji.tsx
@@ -14,6 +14,8 @@ export const getActivityEmoji = (type: string, isBislettInterval?: boolean | und
       return '⛷';
     case 'Swim':
       return '🏊‍♂️';
+    case 'Rowing':
+      return '🚣‍♂️';
     default:
       return '';
   }

--- a/Activities.Web/Pages/Intervals/IntervalsController.cs
+++ b/Activities.Web/Pages/Intervals/IntervalsController.cs
@@ -75,8 +75,9 @@ namespace Activities.Web.Pages.Intervals
                                         Date = activity.Activity.StartDate.ToString("ddd dd. MMM"),
                                         activity.Activity.Name,
                                         activity.Activity.Description,
+                                        activity.Activity.Type,
                                         Interval_AveragePace = activity.IntervalLaps.AverageBy(lap => lap.ElapsedTime, lap => lap.AverageSpeed)
-                                            .Value.ToPaceString(),
+                                            .Value.ToPaceString(activity.Activity.Type),
                                         Interval_AverageHeartrate = $"{activity.IntervalLaps.Average(lap => lap.AverageHeartrate):0} bpm",
                                         Interval_Laps = GetLapsResult(activity.IntervalLaps, maxDistance, maxSpeed, maxHeartrate, maxDuration),
                                         Laktat = GetLactate(activity.Activity),
@@ -198,9 +199,9 @@ namespace Activities.Web.Pages.Intervals
                         var averageMediumPace = mediumPaces.Any() ? mediumPaces.Average() : 0;
                         var averageLongPace = longPaces.Any() ? longPaces.Average() : 0;
 
-                        var shortString = averageShortPace > 0 ? $"\r\n- Short: {averageShortPace.ToPaceString()} (< 2 min)" : null;
-                        var mediumString = averageMediumPace > 0 ? $"\r\n- Medium: {averageMediumPace.ToPaceString()}" : null;
-                        var longString = averageLongPace > 0 ? $"\r\n- Long: {averageLongPace.ToPaceString()} (> 10 min)" : null;
+                        var shortString = averageShortPace > 0 ? $"\r\n- Short: {averageShortPace.ToPaceString(filterRequest.Type)} (< 2 min)" : null;
+                        var mediumString = averageMediumPace > 0 ? $"\r\n- Medium: {averageMediumPace.ToPaceString(filterRequest.Type)}" : null;
+                        var longString = averageLongPace > 0 ? $"\r\n- Long: {averageLongPace.ToPaceString(filterRequest.Type)} (> 10 min)" : null;
 
                         return new
                         {

--- a/Activities.Web/Pages/Threshold/ThresholdController.cs
+++ b/Activities.Web/Pages/Threshold/ThresholdController.cs
@@ -40,11 +40,16 @@ namespace Activities.Web.Pages.Threshold
 
             var medianPace = laps.Select(lap => lap.AverageSpeed).Median();
 
+            // Average pace will show min/500m if showing only rowing activities, and min/km
+            // otherwise (including if filter is set to “all”, no matter what kinds of
+            // activities are actually visible).
+            var activityType = filterRequest.Type;
+
             return new
             {
-                MedianPace = medianPace.ToPaceString(),
-                MinPace = (medianPace - 0.4).ToPaceString(),
-                MaxPace = (medianPace + 0.4).ToPaceString()
+                MedianPace = medianPace.ToPaceString(activityType),
+                MinPace = (medianPace - 0.4).ToPaceString(activityType),
+                MaxPace = (medianPace + 0.4).ToPaceString(activityType)
             };
         }
     }


### PR DESCRIPTION
To a first approximation, this is just about adding it to the filter; all the activities are already downloaded, so we just didn't show them before. Rowing (in particular indoor rowing) is useful for runners that use it as cross-training or during injury recovery.

However, rowing pace is traditionally given in time per 500m, not time per kilometer as running typically is—even though it's roughly in the same range. (E.g., I usually row somewhere around 1:55/500m, which is more intense for me than running at 3:50/km, but both are entirely doable.) Thus, we make an effort to switch pace; the pace formatters (both in C# and in TypeScript) now support taking in an activity type, and when it's rowing, we switch to pace/500m.

When we show values pertinent to multiple activities (e.g. average pace per week), we use the more universal pace/km, but when we show individual activities, or we filter only on rowing activities, we switch to pace/500m even for averages and such. Graphed values are of course still based on km/h, so the bars don't get larger or smaller based on this.