### PR TITLE
Lap time adjustment pace estimation/threshold data import

### DIFF
--- a/Activities.Strava/Activities/ActivitySummary.cs
+++ b/Activities.Strava/Activities/ActivitySummary.cs
@@ -55,7 +55,9 @@ namespace Activities.Strava.Activities
                             {
                                 var thresholdLaps = activity.Laps
                                     .Where(
-                                        lap => lap.ElapsedTime > 120 &&
+                                        // Strides (100m up/down acceleration) are no more than 30 seconds, include every lap above that
+                                        // Ingebrigtsen hill sprints (200 meters/40 seconds) and popular 45/15 workouts considered threshold if within pace
+                                        lap => lap.ElapsedTime > 30 &&
                                                lap.AverageSpeed >= filterRequest.MinPace.Value.ToMetersPerSecond() &&
                                                lap.AverageSpeed <= filterRequest.MaxPace.Value.ToMetersPerSecond())
                                     .ToList();

--- a/Activities.Web/Pages/Threshold/ThresholdController.cs
+++ b/Activities.Web/Pages/Threshold/ThresholdController.cs
@@ -34,13 +34,12 @@ namespace Activities.Web.Pages.Threshold
                 .Where(filterRequest.Keep)
                 .ToList();
 
-            // Strides (100m up/down acceleration) are no more than 30 seconds
-            // Ingebrigtsen hill sprints (200 meters) and popular 45/15 workouts, considered threshold if within pace
+            // Exclude laps shorter than 120 seconds from threshold pace estimation, will likely give uneven results
             var laps = (await activityList.ForEachAsync(4,
                     activity => _activitiesClient.GetActivity(stravaAthlete.AccessToken, stravaAthlete.AthleteId,
                         activity.Id)))
-                .Where(activity => activity?.Laps?.Any(lap => lap.IsInterval && lap.ElapsedTime > 30) == true)
-                .SelectMany(activity => activity.Laps.Where(lap => lap.IsInterval && lap.ElapsedTime > 30))
+                .Where(activity => activity?.Laps?.Any(lap => lap.IsInterval && lap.ElapsedTime > 120) == true)
+                .SelectMany(activity => activity.Laps.Where(lap => lap.IsInterval && lap.ElapsedTime > 120))
                 .ToList();
 
             var medianPace = laps.Select(lap => lap.AverageSpeed).Median();


### PR DESCRIPTION
Reverse lap time adjustment for for threshold pace estimation which gives uneven results.

Reduce lap time for laps to import, to make short intervals show up on threshold data.