### PR TITLE
Never consider Bislett-marked activities as treadmill activities.

### DIFF
--- a/Activities.Strava/Activities/BislettService.cs
+++ b/Activities.Strava/Activities/BislettService.cs
@@ -70,7 +70,7 @@ public static class BislettService
 
         var isTooCloseTo500Meters = intervalLaps.All(lap => GetDistanceFactor(lap.Distance, 500) < Max500MeterFactor);
 
-        if (isTooCloseToAWholeMinute || isTooCloseToWhole100Meter || isTooCloseTo500Meters)
+        if ((isTooCloseToAWholeMinute || isTooCloseToWhole100Meter || isTooCloseTo500Meters) && !activityContainsBislett)
         {
         }
         else if (maxFactor < MaxDistanceFactor && averageFactor < MaxAverageDistanceFactor)


### PR DESCRIPTION
Certain groups, e.g. G4.4, have intervals that end up consistently near 5 minutes, which are then discounted as “too round”, with the idea that they are probably treadmill activities. (Also, doing only double laps would be close to 1100m, which is also “too round”.) This prevents these from being Bislett activities even if they are explicitly marked as such.

As a workaround, never invoke this logic if the activity is explicitly marked as Bislett. Note that this will break e.g. 10x1000m on Bislett and round them to whole rounds, if people run those indoor and tag them as Bislett.