### PR TITLE
Support manual overrides of interval distances.

### DIFF
--- a/Activities.Strava/Activities/ManualSpeedOverrideService.cs
+++ b/Activities.Strava/Activities/ManualSpeedOverrideService.cs
@@ -15,9 +15,15 @@ namespace Activities.Strava.Activities
     //   1-5: 15.3 km/t (or km/h)
     //   1-5: 15,3 km/t (or km/h)
     //   1,3,5,7-9: 15,3 km/t (or km/h)
+    //   1-5: 546.5 m (no support for km, to avoid parse confusion with km/h)
     //
     // Where e.g. 1-5 can be a range or just a single number. If overlapping overrides
     // exist, it is undefined which one wins.
+    //
+    // For speed overrides, the lap index is before interval detection (so that
+    // it can be used to influence it), but distance overrides refer to interval numbers,
+    // as these are typically smaller adjustments (and they also need to run after
+    // Bislett adjustments, to be able to override them).
     public static class ManualSpeedOverrideService
     {
         public static DetailedActivity TryParseManualSpeedOverrides(this DetailedActivity activity)
@@ -45,7 +51,41 @@ namespace Activities.Strava.Activities
                 };
             }
 
-            // Recalculate global values, now that we may have changed laps.
+            return RecalcGlobalValues(activity);
+        }
+
+        public static DetailedActivity TryParseManualDistanceOverrides(this DetailedActivity activity)
+        {
+            var overrides = GetDistanceOverridesFromDescription(activity.Description);
+            overrides.AddRange(GetDistanceOverridesFromDescription(activity.PrivateNote));
+            if (!overrides.Any())
+            {
+                return activity;
+            }
+
+            foreach (var o in overrides)
+            {
+                var intervalIndex = 0;
+                activity = activity with
+                {
+                    Laps = activity.Laps
+                        .Select((lap, index) => lap.IsInterval && intervalIndex++ == o.Lap ? lap with
+                        {
+                            MovingTime = lap.ElapsedTime,
+                            AverageSpeed = o.Distance / lap.ElapsedTime,
+                            MaxSpeed = o.Distance / lap.ElapsedTime,
+                            Distance = o.Distance
+                        } : lap)
+                        .ToList()
+                };
+            }
+
+            return RecalcGlobalValues(activity);
+        }
+
+        // Recalculate global values, now that we may have changed laps.
+        static DetailedActivity RecalcGlobalValues(this DetailedActivity activity)
+        {
             activity = activity with
             {
                 Distance = activity.Laps.Sum((lap) => lap.Distance),
@@ -60,6 +100,8 @@ namespace Activities.Strava.Activities
             return activity;
         }
 
+        const String lapsRegex = @"(?<laps> \d+ (?: [-–] \d+ )? (?: \s* , \s* \d+ (?: [-–] \d+ )? )* )";
+
         public static List<(double Speed, int Lap)> GetSpeedOverridesFromDescription(string description)
         {
             var result = new List<(double Speed, int Lap)>();
@@ -68,8 +110,6 @@ namespace Activities.Strava.Activities
             {
                 return result;
             }
-
-            var lapsRegex = @"(?<laps> \d+ (?: [-–] \d+ )? (?: \s* , \s* \d+ (?: [-–] \d+ )? )* )";
 
             var paceMatches = Regex.Matches(
                 description,
@@ -97,6 +137,32 @@ namespace Activities.Strava.Activities
                 foreach (var lap in ParseLapRanges(match.Groups["laps"].Value))
                 {
                     result.Add((speed, lap));
+                }
+            }
+
+            return result;
+        }
+
+        public static List<(double Distance, int Lap)> GetDistanceOverridesFromDescription(string description)
+        {
+            var result = new List<(double Speed, int Lap)>();
+
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                return result;
+            }
+
+            var distanceMatches = Regex.Matches(
+                description,
+                lapsRegex + @"\s* : \s* (?<dist> \d+ (?: [.,] \d* )? ) \s* m",
+                RegexOptions.Multiline | RegexOptions.IgnorePatternWhitespace);
+            foreach (Match match in distanceMatches)
+            {
+                var distance = Convert.ToDouble(match.Groups["dist"].Value.Replace(",", "."),
+                    CultureInfo.InvariantCulture);
+                foreach (var lap in ParseLapRanges(match.Groups["laps"].Value))
+                {
+                    result.Add((distance, lap));
                 }
             }
 

--- a/Activities.Strava/Endpoints/ActivitiesClient.cs
+++ b/Activities.Strava/Endpoints/ActivitiesClient.cs
@@ -83,6 +83,7 @@ namespace Activities.Strava.Endpoints
             activity = activity.TryParseLactateMeasurements();
             activity = activity.TryParseFeelingParameter();
             activity = activity.TryAdjustBislettLaps();
+            activity = activity.TryParseManualDistanceOverrides();
             return activity;
         }
 


### PR DESCRIPTION
Very similar to the existing override of interval speeds, except:

 - The overridden value is distance, not speed.
 - It is run after interval detection (and accordingly uses interval indexes, not lap indexes).

The main intended purpose is to make small corrections in lap distance when running on outdoor track, e.g., the watch measured 395 m but you know you ran exactly one lap. In this aspect, it is similar to the existing indoor Bislett distance detection (and runs after it), except that this is not automatic.